### PR TITLE
`earliest_date` causes error

### DIFF
--- a/resources/blueprints/collections/episodes/episodes.yaml
+++ b/resources/blueprints/collections/episodes/episodes.yaml
@@ -127,7 +127,6 @@ sections:
           mode: single
           time_enabled: true
           time_required: false
-          earliest_date: '1900-01-01'
           full_width: false
           inline: false
           columns: 1


### PR DESCRIPTION
Due to: https://github.com/statamic/cms/issues/4669